### PR TITLE
Add accessor for the yq logger instance

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -11,6 +11,11 @@ import (
 
 var log = logging.MustGetLogger("yq-lib")
 
+// GetLogger returns the yq logger instance.
+func GetLogger() *logging.Logger {
+	return log
+}
+
 type OperationType struct {
 	Type       string
 	NumArgs    uint // number of arguments to the op

--- a/pkg/yqlib/lib_test.go
+++ b/pkg/yqlib/lib_test.go
@@ -1,0 +1,10 @@
+package yqlib
+
+import "testing"
+
+func TestGetLogger(t *testing.T) {
+	l := GetLogger()
+	if l != log {
+		t.Fatal("GetLogger should return the yq logger instance, not a copy")
+	}
+}


### PR DESCRIPTION
Allow consumers of yqlib to customize the logger instance.

Closes #432

Signed-off-by: Carolyn Van Slyck <me@carolynvanslyck.com>